### PR TITLE
ci only on lowest and newest supported python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.14']
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Noticed that CI was only running up to Python 3.12. Switching to running on lowest (3.9) and highest (3.14) supported Python version - this is what we do in PyFixest. 