### PR TITLE
Normalize Mundlak event studies at period before treatment

### DIFF
--- a/duckreg/dbreg.py
+++ b/duckreg/dbreg.py
@@ -475,6 +475,17 @@ class DBMundlakEventStudy(DBReg):
         self.cluster_col = cluster_col
         self.pre_treat_interactions = pre_treat_interactions
 
+    @staticmethod
+    def _reference_period(cohort):
+        """Absolute time period used as the event-study normalization.
+
+        Event-study coefficients are reported relative to period -1, i.e. the
+        period immediately before treatment begins for each adoption cohort.
+        With absolute time indexing, that reference period is ``cohort - 1``.
+        """
+
+        return cohort - 1
+
     def prepare_data(self):
         t = self.table_expr()
         treated = (
@@ -501,7 +512,10 @@ class DBMundlakEventStudy(DBReg):
         }
         treatment_cols = {}
         for cohort in self.cohorts:
+            reference_period = self._reference_period(cohort)
             for i in range(int(self.num_periods) + 1):
+                if i == reference_period:
+                    continue
                 condition = (cohort_data.cohort == cohort) & (
                     cohort_data[self.time_col] == i
                 )
@@ -563,9 +577,18 @@ class DBMundlakEventStudy(DBReg):
         event_study_coefs = {}
         for cohort in self.cohorts:
             cohort_name = str(cohort)
-            offset = res.filter(regex=f"^cohort_{cohort_name}$", axis=0).values
-            event_study_coefs[cohort_name] = (
-                res.filter(regex=f"^treatment_time_{cohort_name}_", axis=0) + offset
+            reference_period = self._reference_period(cohort)
+            estimates = []
+            index = []
+            for i in range(int(self.num_periods) + 1):
+                name = f"treatment_time_{cohort_name}_{i}"
+                index.append(name)
+                if i == reference_period:
+                    estimates.append(0.0)
+                else:
+                    estimates.append(float(res.loc[name, "est"]))
+            event_study_coefs[cohort_name] = pd.DataFrame(
+                {"est": estimates}, index=index
             )
         return event_study_coefs
 

--- a/duckreg/estimators.py
+++ b/duckreg/estimators.py
@@ -1170,6 +1170,17 @@ class DuckMundlakEventStudy(DuckReg):
         self.cluster_col = cluster_col
         self.pre_treat_interactions = pre_treat_interactions
 
+    @staticmethod
+    def _reference_period(cohort):
+        """Absolute time period used as the event-study normalization.
+
+        Event-study coefficients are reported relative to period -1, i.e. the
+        period immediately before treatment begins for each adoption cohort.
+        With absolute time indexing, that reference period is ``cohort - 1``.
+        """
+
+        return cohort - 1
+
     def prepare_data(self):
         # Create cohort data using CTE instead of temp table
         self.cohort_cte = f"""
@@ -1213,7 +1224,10 @@ class DuckMundlakEventStudy(DuckReg):
         # generate_treatment_dummies
         treatment_dummies = []
         for cohort in self.cohorts:
+            reference_period = self._reference_period(cohort)
             for i in range(self.num_periods + 1):
+                if i == reference_period:
+                    continue
                 treatment_dummies.append(
                     f"""CASE WHEN cohort = {cohort} AND
                         {self.time_col} = {i}
@@ -1252,6 +1266,7 @@ class DuckMundlakEventStudy(DuckReg):
             f"treatment_time_{cohort}_{i}"
             for cohort in self.cohorts
             for i in range(self.num_periods + 1)
+            if i != self._reference_period(cohort)
         ]
 
         rhs_cols = ["intercept"] + cohort_cols + time_cols + treatment_cols
@@ -1286,6 +1301,25 @@ class DuckMundlakEventStudy(DuckReg):
         X = X.reshape(-1, 1) if X.ndim == 1 else X
         return y, X, n
 
+    def _event_study_from_res(self, res):
+        event_study_coefs = {}
+        for cohort in self.cohorts:
+            cohort_name = str(cohort)
+            reference_period = self._reference_period(cohort)
+            estimates = []
+            index = []
+            for i in range(self.num_periods + 1):
+                name = f"treatment_time_{cohort_name}_{i}"
+                index.append(name)
+                if i == reference_period:
+                    estimates.append(0.0)
+                else:
+                    estimates.append(float(res.loc[name, "est"]))
+            event_study_coefs[cohort_name] = pd.DataFrame(
+                {"est": estimates}, index=index
+            )
+        return event_study_coefs
+
     def estimate(self):
         y, X, n = self.collect_data(data=self.df_compressed)
         coef = wls(X, y, n)
@@ -1295,15 +1329,7 @@ class DuckMundlakEventStudy(DuckReg):
             },
             index=self._rhs_list,
         )
-        cohort_names = [x.split("_")[1] for x in self._rhs_list if "cohort_" in x]
-        event_study_coefs = {}
-        for c in cohort_names:
-            offset = res.filter(regex=f"^cohort_{c}", axis=0).values
-            event_study_coefs[c] = (
-                res.filter(regex=f"treatment_time_{c}_", axis=0) + offset
-            )
-
-        return event_study_coefs
+        return self._event_study_from_res(res)
 
     def bootstrap(self):
         # list all clusters
@@ -1362,12 +1388,7 @@ class DuckMundlakEventStudy(DuckReg):
                 },
                 index=self._rhs_list,
             )
-            cohort_names = [x.split("_")[1] for x in self._rhs_list if "cohort_" in x]
-            for c in cohort_names:
-                offset = res.filter(regex=f"^cohort_{c}", axis=0).values
-                event_study_coefs = (
-                    res.filter(regex=f"treatment_time_{c}_", axis=0) + offset
-                )
+            for c, event_study_coefs in self._event_study_from_res(res).items():
                 boot_coefs[c].append(event_study_coefs.values.flatten())
 
         # Calculate the covariance matrix for each cohort

--- a/tests/test_dbreg_glm_event.py
+++ b/tests/test_dbreg_glm_event.py
@@ -325,3 +325,10 @@ def test_db_event_study_matches_duck_event_study(tmp_path):
     assert new_est.keys() == old_est.keys()
     for cohort in old_est:
         pd.testing.assert_frame_equal(new_est[cohort], old_est[cohort], check_exact=False)
+
+    for estimator in (old, new):
+        assert "treatment_time_2_1" not in estimator.rhs_cols
+        assert "treatment_time_3_2" not in estimator.rhs_cols
+
+    assert old_est["2"].loc["treatment_time_2_1", "est"] == 0.0
+    assert old_est["3"].loc["treatment_time_3_2", "est"] == 0.0

--- a/tests/test_dbreg_glm_event.py
+++ b/tests/test_dbreg_glm_event.py
@@ -332,3 +332,109 @@ def test_db_event_study_matches_duck_event_study(tmp_path):
 
     assert old_est["2"].loc["treatment_time_2_1", "est"] == 0.0
     assert old_est["3"].loc["treatment_time_3_2", "est"] == 0.0
+
+
+def test_db_event_study_ibis_materialization_omits_reference_periods(tmp_path):
+    rows = []
+    for unit, cohort in [(1, 2), (2, 3), (3, None), (4, 2), (5, None), (6, 3)]:
+        for time in range(5):
+            treated = int(cohort is not None and time >= cohort)
+            y = 1.0 + 0.2 * unit + 0.3 * time + 0.8 * treated
+            rows.append((unit, time, treated, y, unit))
+    df = pd.DataFrame(rows, columns=["unit", "time", "D", "Y", "cluster"])
+    con = _make_con(tmp_path, df)
+
+    model = DBMundlakEventStudy(
+        db_name=None,
+        connection=con,
+        table_name="data",
+        outcome_var="Y",
+        treatment_col="D",
+        unit_col="unit",
+        time_col="time",
+        cluster_col="cluster",
+        seed=43,
+        n_bootstraps=0,
+        pre_treat_interactions=True,
+    )
+    model.prepare_data()
+
+    assert isinstance(model.design_matrix, ibis.expr.types.Table)
+    assert "treatment_time_2_1" not in model.design_matrix.columns
+    assert "treatment_time_3_2" not in model.design_matrix.columns
+    assert "treatment_time_2_0" in model.design_matrix.columns
+    assert "treatment_time_3_1" in model.design_matrix.columns
+
+    model.compress_data()
+    assert "treatment_time_2_1" not in model.rhs_cols
+    assert "treatment_time_3_2" not in model.rhs_cols
+    assert all("treatment_time_2_1" not in col for col in model.df_compressed.columns)
+    assert all("treatment_time_3_2" not in col for col in model.df_compressed.columns)
+
+    model.point_estimate = model.estimate()
+    assert model.point_estimate["2"].loc["treatment_time_2_1", "est"] == 0.0
+    assert model.point_estimate["3"].loc["treatment_time_3_2", "est"] == 0.0
+
+
+def test_db_event_study_uses_ref_minus_one_normalization(tmp_path):
+    rows = []
+    for unit, cohort in [(1, 2), (2, 3), (3, None), (4, 2), (5, None), (6, 3)]:
+        unit_fe = 0.25 * unit
+        for time in range(5):
+            treated = int(cohort is not None and time >= cohort)
+            rel_time = time - cohort if cohort is not None else None
+            effect = (
+                0.0
+                if not treated
+                else {0: 0.7, 1: 1.1, 2: 1.4}.get(rel_time, 1.4)
+            )
+            y = 2.0 + unit_fe + 0.4 * time + effect
+            rows.append((unit, time, treated, y, unit))
+    df = pd.DataFrame(rows, columns=["unit", "time", "D", "Y", "cluster"])
+    con = _make_con(tmp_path, df)
+
+    model = DBMundlakEventStudy(
+        db_name=None,
+        connection=con,
+        table_name="data",
+        outcome_var="Y",
+        treatment_col="D",
+        unit_col="unit",
+        time_col="time",
+        cluster_col="cluster",
+        seed=44,
+        n_bootstraps=0,
+        pre_treat_interactions=True,
+    )
+    model.fit()
+    estimates = model.summary()["point_estimate"]
+
+    assert estimates["2"].index.tolist() == [
+        "treatment_time_2_0",
+        "treatment_time_2_1",
+        "treatment_time_2_2",
+        "treatment_time_2_3",
+        "treatment_time_2_4",
+    ]
+    assert estimates["3"].index.tolist() == [
+        "treatment_time_3_0",
+        "treatment_time_3_1",
+        "treatment_time_3_2",
+        "treatment_time_3_3",
+        "treatment_time_3_4",
+    ]
+    assert estimates["2"].loc["treatment_time_2_1", "est"] == 0.0
+    assert estimates["3"].loc["treatment_time_3_2", "est"] == 0.0
+    np.testing.assert_allclose(
+        estimates["2"].loc[
+            ["treatment_time_2_2", "treatment_time_2_3", "treatment_time_2_4"],
+            "est",
+        ],
+        [0.7, 1.1, 1.4],
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        estimates["3"].loc[["treatment_time_3_3", "treatment_time_3_4"], "est"],
+        [0.7, 1.1],
+        atol=1e-12,
+    )


### PR DESCRIPTION
## Summary
- omit each cohort's period immediately before adoption from Mundlak event-study designs
- report the omitted reference period as zero in event-study summaries
- apply the same normalization to the SQL-string and Ibis implementations
- add explicit Ibis materialization and normalization tests

## Verification
- uv run pytest -q
- issue #13 notebook DGP with 100k units / 50k treated: max abs delta vs feols was ~1.1e-10 for seeds 42 and 421

Fixes #13